### PR TITLE
Added spark internal rgb support

### DIFF
--- a/lib/spark.js
+++ b/lib/spark.js
@@ -337,6 +337,17 @@ Spark.prototype.pinMode = function(pin, mode) {
   return this;
 };
 
+Spark.prototype["setInternalRGB"] = function(red, green, blue){
+  var state = priv.get(this);
+  var buffer = new Buffer(4);
+  buffer[0] = 0x07;
+  buffer[1] = red;
+  buffer[2] = green;
+  buffer[3] = blue;
+  state.socket.write(buffer);
+  return this;
+};
+
 ["analogWrite", "digitalWrite", "servoWrite"].forEach(function(fn) {
   var isAnalog = fn === "analogWrite";
   var isServo = fn === "servoWrite";


### PR DESCRIPTION
According to changes on this pull request
https://github.com/voodootikigod/voodoospark/pull/40
I added the function for controlling spark rgb internal led.
This only works on the spark board.
To inject it on the johnny-five repl I used this code

```javascript
var set_internal_RGB;
spark_board.on("ready", function(){
  var that = this;
  set_internal_RGB = function(red, green, blue){
    that.setInternalRGB.call(that, red, green, blue);
  }
})

board.on("ready", function() {
  this.repl.inject({
    setInternalRGB: set_internal_RGB
  });
});
```