### PR TITLE
Re-branded everything as Particle instead of Spark

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
     pkg: grunt.file.readJSON("package.json"),
     nodeunit: {
       tests: [
-        "test/spark.js"
+        "test/particle.js"
       ]
     },
     jshint: {

--- a/docs/led-rgb.md
+++ b/docs/led-rgb.md
@@ -8,16 +8,16 @@ node eg/led-rgb.js
 
 ``` javascript
 var five = require("johnny-five"),
-  Spark = require("../lib/spark"),
+  Particle = require("../lib/particle"),
   keypress = require('keypress'),
   board;
 
 
-// Create Johnny-Five board connected via Spark
+// Create Johnny-Five board connected via Particle
 board = new five.Board({
-  io: new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+  io: new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.PARTICLE_DEVICE_ID
   })
 });
 

--- a/docs/servo-continuous.md
+++ b/docs/servo-continuous.md
@@ -8,14 +8,14 @@ node eg/servo-continuous.js
 
 ``` javascript
 var five = require("johnny-five"),
-  Spark = require("../lib/spark"),
+  Particle = require("../lib/particle"),
   board;
 
-// Create Johnny-Five board connected via Spark
+// Create Johnny-Five board connected via Particle
 board = new five.Board({
-  io: new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+  io: new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.PARTICLE_DEVICE_ID
   })
 });
 

--- a/docs/servo-keypress.md
+++ b/docs/servo-keypress.md
@@ -8,15 +8,15 @@ node eg/servo-keypress.js
 
 ``` javascript
 var five     = require("johnny-five");
-var Spark    = require("../lib/spark");
+var Particle    = require("../lib/particle");
 var keypress = require('keypress');
 
 keypress(process.stdin);
 
 var board = new five.Board({
-  io: new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+  io: new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.PARTICLE_DEVICE_ID
   })
 });
 

--- a/docs/servo-prompt.md
+++ b/docs/servo-prompt.md
@@ -7,7 +7,7 @@ node eg/servo-prompt.js
 
 
 ``` javascript
-var Spark    = require('../lib/spark');
+var Particle    = require('../lib/particle');
 var readline = require('readline');
 
 var rl = readline.createInterface({
@@ -16,9 +16,9 @@ var rl = readline.createInterface({
 });
 
 
-var board = new Spark({
-  token: process.env.SPARK_TOKEN,
-  deviceId: process.env.SPARK_DEVICE_ID
+var board = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceId: process.env.PARTICLE_DEVICE_ID
 });
 
 

--- a/docs/servo.md
+++ b/docs/servo.md
@@ -8,15 +8,15 @@ node eg/servo.js
 
 ``` javascript
 var five = require("johnny-five"),
-  Spark = require("../lib/spark"),
+  Particle = require("../lib/particle"),
   temporal = require('temporal'),
   board;
 
-// Create Johnny-Five board connected via Spark
+// Create Johnny-Five board connected via Particle
 board = new five.Board({
-  io: new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+  io: new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.PARTICLE_DEVICE_ID
   })
 });
 

--- a/eg/analog-multi.js
+++ b/eg/analog-multi.js
@@ -1,7 +1,7 @@
-var Spark = require("../lib/spark");
-var board = new Spark({
-  token: process.env.SPARK_TOKEN,
-  deviceId: process.env.SPARK_DEVICE_BLACK
+var Particle = require("../lib/particle");
+var board = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceId: process.env.PARTICLE_DEVICE_BLACK
 });
 
 board.on("ready", function() {

--- a/eg/blink.js
+++ b/eg/blink.js
@@ -1,7 +1,7 @@
 var Particle = require("../lib/particle");
 var board = new Particle({
   token: process.env.PARTICLE_TOKEN,
-  deviceId: process.env.PARTICLE_DEVICE_BLACK
+  deviceId: process.env.PARTICLE_DEVICE_ID
 });
 
 board.on("ready", function() {

--- a/eg/blink.js
+++ b/eg/blink.js
@@ -1,7 +1,7 @@
-var Spark = require("../lib/spark");
-var board = new Spark({
-  token: process.env.SPARK_TOKEN,
-  deviceId: process.env.SPARK_DEVICE_ID
+var Particle = require("../lib/particle");
+var board = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceId: process.env.PARTICLE_DEVICE_BLACK
 });
 
 board.on("ready", function() {

--- a/eg/board-multi.js
+++ b/eg/board-multi.js
@@ -1,28 +1,28 @@
 var five = require("johnny-five"),
-  Spark = require("../lib/spark"),
+  Particle = require("../lib/Particle"),
   board;
 
 // Define array of available cores with appropriate DEVICE_IDs for each.
 // Note that the five.Boards(["ID1","ID2"]) shorthand doesn't work for
-// spark-io because we have to pass the io configuration object.
+// particle-io because we have to pass the io configuration object.
 // The five.Boards port option is also not applicable here.
 var cores = [
   {
     id: "A",
-    io: new Spark({
-      token: process.env.SPARK_TOKEN,
-      deviceId: process.env.SPARK_DEVICE_ID_A
+    io: new Particle({
+      token: process.env.PARTICLE_TOKEN,
+      deviceId: process.env.PARTICLE_DEVICE_ID_A
     })
   },{
     id: "B",
-    io: new Spark({
-      token: process.env.SPARK_TOKEN,
-      deviceId: process.env.SPARK_DEVICE_ID_B,
+    io: new Particle({
+      token: process.env.PARTICLE_TOKEN,
+      deviceId: process.env.PARTICLE_DEVICE_ID_B,
     })
   }
 ];
 
-// Create 2 spark board instances
+// Create 2 particle board instances
 new five.Boards(cores).on("ready", function() {
 
   // Both "A" and "B" are initialized
@@ -33,7 +33,7 @@ new five.Boards(cores).on("ready", function() {
   this.each(function(board) {
 
     // Initialize an Led instance on default D7 LED of
-    // each initialized spark core and strobe it.
+    // each initialized particle and strobe it.
     new five.Led({
       pin: "D7",
       board: board

--- a/eg/board.js
+++ b/eg/board.js
@@ -1,12 +1,12 @@
 var five = require("johnny-five"),
-  Spark = require("../lib/spark"),
+  Particle = require("../lib/particle"),
   board;
 
-// Create Johnny-Five board connected via Spark
+// Create Johnny-Five board connected via Particle
 board = new five.Board({
-  io: new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+  io: new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.PARTICLE_DEVICE_ID
   })
 });
 

--- a/eg/crash-test.js
+++ b/eg/crash-test.js
@@ -1,8 +1,8 @@
 var moment = require("moment");
-var Spark = require("../lib/spark");
-var board = new Spark({
-  token: process.env.SPARK_TOKEN,
-  deviceId: process.env.SPARK_DEVICE_ROBOTSCONF
+var Particle = require("../lib/particle");
+var board = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceId: process.env.PARTICLE_DEVICE_ROBOTSCONF
 });
 
 // node eg/crash-test.js

--- a/eg/internal-rgb-rainbow.js
+++ b/eg/internal-rgb-rainbow.js
@@ -1,7 +1,7 @@
-var Spark = require("../lib/spark.js");
-var board = new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID  
+var Particle = require("../lib/particle");
+var board = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceId: process.env.PARTICLE_DEVICE_BLACK
 });
 
 board.on("ready", function() {

--- a/eg/internal-rgb-rainbow.js
+++ b/eg/internal-rgb-rainbow.js
@@ -1,7 +1,7 @@
 var Particle = require("../lib/particle");
 var board = new Particle({
   token: process.env.PARTICLE_TOKEN,
-  deviceId: process.env.PARTICLE_DEVICE_BLACK
+  deviceId: process.env.PARTICLE_DEVICE_ID
 });
 
 board.on("ready", function() {

--- a/eg/led-rgb.js
+++ b/eg/led-rgb.js
@@ -1,14 +1,14 @@
 var five = require("johnny-five"),
-  Spark = require("../lib/spark"),
+  Particle = require("../lib/particle"),
   keypress = require("keypress"),
   board;
 
 
-// Create Johnny-Five board connected via Spark
+// Create Johnny-Five board connected via Particle
 board = new five.Board({
-  io: new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+  io: new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.PARTICLE_DEVICE_ID
   })
 });
 

--- a/eg/read.js
+++ b/eg/read.js
@@ -1,7 +1,7 @@
 var Particle = require("../lib/particle");
 var board = new Particle({
   token: process.env.PARTICLE_TOKEN,
-  deviceId: process.env.PARTICLE_DEVICE_BLACK
+  deviceId: process.env.PARTICLE_DEVICE_ID
 });
 
 board.on("ready", function() {

--- a/eg/read.js
+++ b/eg/read.js
@@ -1,7 +1,7 @@
-var Spark = require("../lib/spark");
-var board = new Spark({
-  token: process.env.SPARK_TOKEN,
-  deviceId: process.env.SPARK_DEVICE_ID
+var Particle = require("../lib/particle");
+var board = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceId: process.env.PARTICLE_DEVICE_BLACK
 });
 
 board.on("ready", function() {

--- a/eg/servo-continuous.js
+++ b/eg/servo-continuous.js
@@ -1,12 +1,12 @@
 var five = require("johnny-five"),
-  Spark = require("../lib/spark"),
+  Particle = require("../lib/particle"),
   board;
 
-// Create Johnny-Five board connected via Spark
+// Create Johnny-Five board connected via Particle
 board = new five.Board({
-  io: new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+  io: new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.PARTICLE_DEVICE_ID
   })
 });
 

--- a/eg/servo-keypress.js
+++ b/eg/servo-keypress.js
@@ -1,13 +1,13 @@
 var five     = require("johnny-five");
-var Spark    = require("../lib/spark");
+var Particle    = require("../lib/particle");
 var keypress = require('keypress');
 
 keypress(process.stdin);
 
 var board = new five.Board({
-  io: new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+  io: new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.Particle_DEVICE_ID
   })
 });
 

--- a/eg/servo-prompt.js
+++ b/eg/servo-prompt.js
@@ -9,7 +9,7 @@ var rl = readline.createInterface({
 
 var board = new Particle({
   token: process.env.PARTICLE_TOKEN,
-  deviceId: process.env.PARTICLE_DEVICE_BLACK
+  deviceId: process.env.PARTICLE_DEVICE_ID
 });
 
 board.on('ready', function() {

--- a/eg/servo-prompt.js
+++ b/eg/servo-prompt.js
@@ -1,4 +1,4 @@
-var Spark    = require('../lib/spark');
+var Particle    = require('../lib/particle');
 var readline = require('readline');
 
 var rl = readline.createInterface({
@@ -7,11 +7,10 @@ var rl = readline.createInterface({
 });
 
 
-var board = new Spark({
-  token: process.env.SPARK_TOKEN,
-  deviceId: process.env.SPARK_DEVICE_ID
+var board = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceId: process.env.PARTICLE_DEVICE_BLACK
 });
-
 
 board.on('ready', function() {
 

--- a/eg/servo.js
+++ b/eg/servo.js
@@ -1,15 +1,16 @@
 var five = require("johnny-five"),
-  Spark = require("../lib/spark"),
+  Particle = require("../lib/particle"),
   temporal = require('temporal'),
   board;
 
-// Create Johnny-Five board connected via Spark
+// Create Johnny-Five board connected via Particle
 board = new five.Board({
-  io: new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+  io: new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.PARTICLE_DEVICE_ID
   })
 });
+
 
 // The board's pins will not be accessible until
 // the board has reported that it is ready

--- a/lib/particle.js
+++ b/lib/particle.js
@@ -7,9 +7,9 @@ var https = require("https");
 var priv = new Map();
 
 var errors = {
-  cloud: "Unable to connect to spark cloud.",
+  cloud: "Unable to connect to particle cloud.",
   firmware: "Unable to connect to the voodoospark firmware, has it been loaded?",
-  instance: "Expected instance of Spark.",
+  instance: "Expected instance of Particle.",
   pwm: "PWM is only available on D0, D1, A0, A1, A4, A5, A6, A7"
 };
 
@@ -59,7 +59,7 @@ var SAMPLE_INTERVAL = 0x06;
 var INTERNAL_RGB = 0x07;
 
 function service(deviceId) {
-  return "https://api.spark.io/v1/devices/" + deviceId + "/";
+  return "https://api.particle.io/v1/devices/" + deviceId + "/";
 }
 
 function from7BitBytes(lsb, msb) {
@@ -75,24 +75,24 @@ function to7BitBytes(value) {
 }
 
 
-function processReceived(spark, data) {
+function processReceived(particle, data) {
   var dlength = data.length;
   var length, action, pin, pinName, pinIndex, port,
       lsb, msb, value, portValue, type, event;
 
   for (var i = 0; i < dlength; i++) {
-    spark.buffer.push(data.readUInt8(i));
+    particle.buffer.push(data.readUInt8(i));
   }
 
-  length = spark.buffer.length;
+  length = particle.buffer.length;
 
   if (length >= 4) {
 
     while (length && (length % 4) === 0) {
-      action = spark.buffer.shift();
-      pin = spark.buffer.shift();
-      lsb = spark.buffer.shift();
-      msb = spark.buffer.shift();
+      action = particle.buffer.shift();
+      pin = particle.buffer.shift();
+      lsb = particle.buffer.shift();
+      msb = particle.buffer.shift();
 
       value = from7BitBytes(lsb, msb);
 
@@ -108,9 +108,9 @@ function processReceived(spark, data) {
           event = "digital-read-" + (port ? "A" : "D") + k;
           value = portValue & (1 << k);
 
-          if (typeof spark._events[event] !== "undefined") {
-            spark.pins[pinIndex].value = value;
-            spark.emit(event, value);
+          if (typeof particle._events[event] !== "undefined") {
+            particle.pins[pinIndex].value = value;
+            particle.emit(event, value);
           }
         }
       }
@@ -136,20 +136,20 @@ function processReceived(spark, data) {
 
         event = type + "-read-" + pinName;
 
-        spark.pins[pin].value = value;
-        spark.emit(event, value);
+        particle.pins[pin].value = value;
+        particle.emit(event, value);
       }
 
-      length = spark.buffer.length;
+      length = particle.buffer.length;
     }
   }
 }
 
-function Spark(opts) {
+function Particle(opts) {
   Emitter.call(this);
 
-  if (!(this instanceof Spark)) {
-    return new Spark(opts);
+  if (!(this instanceof Particle)) {
+    return new Particle(opts);
   }
 
   var state = {
@@ -169,7 +169,7 @@ function Spark(opts) {
     }
   };
 
-  this.name = "spark-io";
+  this.name = "particle-io";
   this.buffer = [];
   this.isReady = false;
 
@@ -210,18 +210,18 @@ function Spark(opts) {
       state.host = address[0];
       state.port = parseInt(address[1], 10);
       // Moving into after connect so we can obtain the ip address
-      Spark.Client.create(this, afterCreate);
+      Particle.Client.create(this, afterCreate);
     }
   }.bind(this));
 }
 
 
-Spark.Client = {
-  create: function(spark, afterCreate) {
-    if (!(spark instanceof Spark)) {
+Particle.Client = {
+  create: function(particle, afterCreate) {
+    if (!(particle instanceof Particle)) {
       throw new Error(errors.instance);
     }
-    var state = priv.get(spark);
+    var state = priv.get(particle);
     var connection = {
       host: state.host,
       port: state.port
@@ -229,13 +229,13 @@ Spark.Client = {
 
     var socket = net.connect(connection, function() {
       // Set ready state bit
-      spark.isReady = true;
-      spark.emit("ready");
+      particle.isReady = true;
+      particle.emit("ready");
 
       if (!state.isReading) {
         state.isReading = true;
         socket.on("data", function(data) {
-          processReceived(spark, data);
+          processReceived(particle, data);
         });
       }
     });
@@ -245,9 +245,9 @@ Spark.Client = {
   }
 };
 
-Spark.prototype = Object.create(Emitter.prototype, {
+Particle.prototype = Object.create(Emitter.prototype, {
   constructor: {
-    value: Spark
+    value: Particle
   },
   MODES: {
     value: modes
@@ -260,7 +260,7 @@ Spark.prototype = Object.create(Emitter.prototype, {
   }
 });
 
-Spark.prototype.connect = function(handler) {
+Particle.prototype.connect = function(handler) {
   var state = priv.get(this);
   var url = state.service;
   var action = "endpoint";
@@ -299,7 +299,7 @@ Spark.prototype.connect = function(handler) {
   return this;
 };
 
-Spark.prototype.pinMode = function(pin, mode) {
+Particle.prototype.pinMode = function(pin, mode) {
   var state = priv.get(this);
   var buffer;
   var offset;
@@ -351,7 +351,7 @@ Spark.prototype.pinMode = function(pin, mode) {
   var isServo = fn === "servoWrite";
   var action = isAnalog ? 0x02 : (isServo ? 0x41 : 0x01);
 
-  Spark.prototype[fn] = function(pin, value) {
+  Particle.prototype[fn] = function(pin, value) {
     var state = priv.get(this);
     var buffer = new Buffer(3);
     var offset = pin[0] === "A" ? 10 : 0;
@@ -379,7 +379,7 @@ Spark.prototype.pinMode = function(pin, mode) {
   var value = isAnalog ? 2 : 1;
   var type = isAnalog ? "analog" : "digital";
 
-  Spark.prototype[fn] = function(pin, handler) {
+  Particle.prototype[fn] = function(pin, handler) {
     var state = priv.get(this);
     var buffer = new Buffer(3);
     var pinInt;
@@ -416,7 +416,7 @@ Spark.prototype.pinMode = function(pin, mode) {
 /**
  * Compatibility Shimming
  */
-Spark.prototype.setSamplingInterval = function(interval) {
+Particle.prototype.setSamplingInterval = function(interval) {
   var state = priv.get(this);
   var safeInterval = Math.max(Math.min(Math.pow(2, 14) - 1, interval), 10);
 
@@ -428,7 +428,7 @@ Spark.prototype.setSamplingInterval = function(interval) {
 };
 
 
-Spark.prototype.internalRGB = function(red, green, blue) {
+Particle.prototype.internalRGB = function(red, green, blue) {
   var state = priv.get(this);
   var data = [INTERNAL_RGB];
   var input, values;
@@ -442,7 +442,7 @@ Spark.prototype.internalRGB = function(red, green, blue) {
     input = red;
 
     if (input === null || input === undefined) {
-      throw new Error("Spark.internalRGB: invalid color (" + input + ")");
+      throw new Error("Particle.internalRGB: invalid color (" + input + ")");
     }
 
     if (typeof input === "object") {
@@ -467,7 +467,7 @@ Spark.prototype.internalRGB = function(red, green, blue) {
         }
 
         if (!input.match(/^[0-9A-Fa-f]{6}$/)) {
-          throw new Error("Spark.internalRGB: invalid color (" + input + ")");
+          throw new Error("Particle.internalRGB: invalid color (" + input + ")");
         }
 
         // internalRGB("ffffff")
@@ -485,7 +485,7 @@ Spark.prototype.internalRGB = function(red, green, blue) {
 
   // Be sure we got all three values from one of the above signatures
   if (values.length !== 3 || values.includes(null) || values.includes(undefined)) {
-    throw new Error("Spark.internalRGB: invalid color ([" + values.join(",") + "])");
+    throw new Error("Particle.internalRGB: invalid color ([" + values.join(",") + "])");
   }
 
   values = values.map(function(value) {
@@ -503,11 +503,11 @@ Spark.prototype.internalRGB = function(red, green, blue) {
   return this;
 };
 
-Spark.prototype.reset = function() {
+Particle.prototype.reset = function() {
   return this;
 };
 
-Spark.prototype.close = function() {
+Particle.prototype.close = function() {
   var state = priv.get(this);
   state.socket.close();
   state.server.close();
@@ -518,4 +518,4 @@ function constrain(value, lower, upper) {
 }
 
 
-module.exports = Spark;
+module.exports = Particle;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spark-io",
-  "description": "Spark Core IO Plugin for Johnny-Five",
+  "description": "Particle IO Plugin for Johnny-Five",
   "version": "0.6.1",
   "homepage": "https://github.com/rwaldron/spark-io",
   "author": {
@@ -15,7 +15,7 @@
     { "name": "Ron Evans", "email": "<ron@hybridgroup.com>" }
   ],
   "keywords": [
-    "spark", "io", "arduino", "firmata", "johnny-five"
+    "particle", "spark", "io", "arduino", "firmata", "johnny-five"
   ],
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
       "url": "https://github.com/rwaldron/spark-io/blob/master/LICENSE-MIT"
     }
   ],
-  "main": "lib/spark",
+  "main": "lib/particle",
   "engines": {
     "node": ">=0.10.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -1,29 +1,29 @@
-# Spark-io
+# Particle-io
 
 [![Build Status](https://travis-ci.org/rwaldron/spark-io.png?branch=master)](https://travis-ci.org/rwaldron/spark-io)
 
-Spark-io is a Firmata-compatibility IO class for writing node programs that interact with [Particle devices](http://docs.particle.io/) (formerly Spark). Spark-io was built at [Bocoup](http://bocoup.com/)
+Particle-io is a Firmata-compatibility IO class for writing node programs that interact with [Particle devices](http://docs.particle.io/) (formerly Spark). Particle-io was built at [Bocoup](http://bocoup.com/)
 
 ### Getting Started
 
-In order to use the spark-io library, you will need to load the special
+In order to use the particle-io library, you will need to load the special
 [voodoospark](https://github.com/voodootikigod/voodoospark) firmware onto your
 device. We recommend you review [VoodooSpark's Getting Started](https://github.com/voodootikigod/voodoospark#getting-started) before continuing.
 
-We also recommend storing your Spark token and device ID in a dot file so they can be accessed as properties of `process.env`. Create a file in your home directory called `.sparkrc` that contains: 
+We also recommend storing your Particle token and device ID in a dot file so they can be accessed as properties of `process.env`. Create a file in your home directory called `.particlerc` that contains: 
 
 ```sh
-export SPARK_TOKEN="your spark token"
-export SPARK_DEVICE_ID="your device id"
+export PARTICLE_TOKEN="your particle token"
+export PARTICLE_DEVICE_ID="your device id"
 ```
 
 Then add the following to your dot-rc file of choice:
 
 ```sh
-source ~/.sparkrc
+source ~/.particlerc
 ```
 
-Ensure your host computer (where you're running your Node.js application) and the Spark are on the same local network.
+Ensure your host computer (where you're running your Node.js application) and the Particle are on the same local network.
 
 ### Blink an Led
 
@@ -31,10 +31,10 @@ Ensure your host computer (where you're running your Node.js application) and th
 The "Hello World" of microcontroller programming:
 
 ```js
-var Spark = require("spark-io");
-var board = new Spark({
-  token: process.env.SPARK_TOKEN,
-  deviceId: process.env.SPARK_DEVICE_ID
+var Particle = require("particle-io");
+var board = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceId: process.env.PARTICLE_DEVICE_ID
 });
 
 board.on("ready", function() {
@@ -52,15 +52,15 @@ board.on("ready", function() {
 
 ### Johnny-Five IO Plugin
 
-Spark-IO can be used as an [IO Plugin](https://github.com/rwaldron/johnny-five/wiki/IO-Plugins) for [Johnny-Five](https://github.com/rwaldron/johnny-five):
+Particle-IO can be used as an [IO Plugin](https://github.com/rwaldron/johnny-five/wiki/IO-Plugins) for [Johnny-Five](https://github.com/rwaldron/johnny-five):
 
 ```js
 var five = require("johnny-five");
-var Spark = require("spark-io");
+var Particle = require("particle-io");
 var board = new five.Board({
-  io: new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+  io: new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.PARTICLE_DEVICE_ID
   })
 });
 
@@ -75,10 +75,10 @@ board.on("ready", function() {
 
 **MODES**
 
-> The `MODES` property is available as a Spark instance property:
+> The `MODES` property is available as a Particle instance property:
 
 ```js
-var board = new Spark(...);
+var board = new Particle(...);
 board.MODES;
 ```
 - INPUT: 0
@@ -95,7 +95,7 @@ board.MODES;
 
 Example:
 ```js
-var board = new Spark(...);
+var board = new Particle(...);
 
 board.on("ready", function() {
 
@@ -116,7 +116,7 @@ board.on("ready", function() {
 
 Example:
 ```js
-var board = new Spark(...);
+var board = new Particle(...);
 
 board.on("ready", function() {
 
@@ -138,7 +138,7 @@ board.on("ready", function() {
 
 Example:
 ```js
-var board = new Spark(...);
+var board = new Particle(...);
 
 board.on("ready", function() {
 
@@ -159,7 +159,7 @@ board.on("ready", function() {
 
 Example:
 ```js
-var board = new Spark(...);
+var board = new Particle(...);
 
 board.on("ready", function() {
 
@@ -176,7 +176,7 @@ board.on("ready", function() {
 
 Example:
 ```js
-var board = new Spark(...);
+var board = new Particle(...);
 
 board.on("ready", function() {
 
@@ -194,7 +194,7 @@ board.on("ready", function() {
 
 Example:
 ```js
-var board = new Spark(...);
+var board = new Particle(...);
 
 board.on("ready", function() {
 

--- a/test/particle.js
+++ b/test/particle.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var Spark = require("../lib/spark");
+var Particle = require("../lib/particle");
 var Emitter = require("events").EventEmitter;
 var sinon = require("sinon");
-var SparkAPIVariable = {cmd: "VarReturn", result: "127.0.0.1:48879"};
+var ParticleAPIVariable = {cmd: "VarReturn", result: "127.0.0.1:48879"};
 
 
 function restore(target) {
@@ -36,14 +36,14 @@ function State() {
   };
 }
 
-sinon.stub(Spark.Client, "create", function(spark, onCreated) {
+sinon.stub(Particle.Client, "create", function(particle, onCreated) {
   process.nextTick(function() {
-    spark.emit("ready");
+    particle.emit("ready");
   });
   process.nextTick(onCreated);
 });
 
-exports["Spark"] = {
+exports["Particle"] = {
   setUp: function(done) {
 
     this.clock = sinon.useFakeTimers();
@@ -51,11 +51,11 @@ exports["Spark"] = {
     this.state = new State();
     this.map = sinon.stub(Map.prototype, "get").returns(this.state);
     this.socketwrite = sinon.spy(this.state.socket, "write");
-    this.connect = sinon.stub(Spark.prototype, "connect", function(handler) {
+    this.connect = sinon.stub(Particle.prototype, "connect", function(handler) {
       handler(null, {cmd: "VarReturn", result: "127.0.0.1:48879"});
     });
 
-    this.spark = new Spark({
+    this.particle = new Particle({
       token: "token",
       deviceId: "deviceId"
     });
@@ -109,19 +109,19 @@ exports["Spark"] = {
     );
 
     this.proto.functions.forEach(function(method) {
-      test.equal(typeof this.spark[method.name], "function");
+      test.equal(typeof this.particle[method.name], "function");
     }, this);
 
     this.proto.objects.forEach(function(method) {
-      test.equal(typeof this.spark[method.name], "object");
+      test.equal(typeof this.particle[method.name], "object");
     }, this);
 
     this.proto.numbers.forEach(function(method) {
-      test.equal(typeof this.spark[method.name], "number");
+      test.equal(typeof this.particle[method.name], "number");
     }, this);
 
     this.instance.forEach(function(property) {
-      test.notEqual(typeof this.spark[property.name], "undefined");
+      test.notEqual(typeof this.particle[property.name], "undefined");
     }, this);
 
     test.done();
@@ -129,19 +129,19 @@ exports["Spark"] = {
   readonly: function(test) {
     test.expect(7);
 
-    test.equal(this.spark.HIGH, 1);
+    test.equal(this.particle.HIGH, 1);
 
     test.throws(function() {
-      this.spark.HIGH = 42;
+      this.particle.HIGH = 42;
     });
 
-    test.equal(this.spark.LOW, 0);
+    test.equal(this.particle.LOW, 0);
 
     test.throws(function() {
-      this.spark.LOW = 42;
+      this.particle.LOW = 42;
     });
 
-    test.deepEqual(this.spark.MODES, {
+    test.deepEqual(this.particle.MODES, {
       INPUT: 0,
       OUTPUT: 1,
       ANALOG: 2,
@@ -150,24 +150,24 @@ exports["Spark"] = {
     });
 
     test.throws(function() {
-      this.spark.MODES.INPUT = 42;
+      this.particle.MODES.INPUT = 42;
     });
 
     test.throws(function() {
-      this.spark.MODES = 42;
+      this.particle.MODES = 42;
     });
 
     test.done();
   },
   emitter: function(test) {
     test.expect(1);
-    test.ok(this.spark instanceof Emitter);
+    test.ok(this.particle instanceof Emitter);
     test.done();
   },
   connected: function(test) {
     test.expect(1);
 
-    this.spark.on("connect", function() {
+    this.particle.on("connect", function() {
       test.ok(true);
       test.done();
     });
@@ -175,7 +175,7 @@ exports["Spark"] = {
   ready: function(test) {
     test.expect(1);
 
-    this.spark.on("ready", function() {
+    this.particle.on("ready", function() {
       test.ok(true);
       test.done();
     });
@@ -188,7 +188,7 @@ exports["Spark"] = {
   "analogRead",
   "digitalRead"
 ].forEach(function(fn) {
-  var entry = "Spark.prototype." + fn;
+  var entry = "Particle.prototype." + fn;
   var action = fn.toLowerCase();
   var isAnalog = action === "analogwrite" || action === "analogread";
 
@@ -212,11 +212,11 @@ exports["Spark"] = {
       this.state = new State();
       this.map = sinon.stub(Map.prototype, "get").returns(this.state);
       this.socketwrite = sinon.spy(this.state.socket, "write");
-      this.connect = sinon.stub(Spark.prototype, "connect", function(handler) {
+      this.connect = sinon.stub(Particle.prototype, "connect", function(handler) {
         handler(null, {cmd: "VarReturn", result: "127.0.0.1:48879"});
       });
 
-      this.spark = new Spark({
+      this.particle = new Particle({
         token: "token",
         deviceId: "deviceId"
       });
@@ -246,7 +246,7 @@ exports["Spark"] = {
         test.done();
       };
 
-      this.spark[fn](pin, handler);
+      this.particle[fn](pin, handler);
 
       var buffer = this.socketwrite.args[0][0];
 
@@ -265,7 +265,7 @@ exports["Spark"] = {
         test.done();
       };
 
-      this.spark[fn](pin, handler);
+      this.particle[fn](pin, handler);
       this.state.socket.emit("data", receiving);
     };
 
@@ -274,14 +274,14 @@ exports["Spark"] = {
 
       var event = type + "-read-" + pin;
 
-      this.spark.once(event, function(data) {
+      this.particle.once(event, function(data) {
         test.equal(data, value);
         test.done();
       });
 
       var handler = function(data) {};
 
-      this.spark[fn](pin, handler);
+      this.particle[fn](pin, handler);
       this.state.socket.emit("data", receiving);
     };
 
@@ -296,7 +296,7 @@ exports["Spark"] = {
         };
 
         // Analog read on pin 0 (zero), which is A0 or 10
-        this.spark.analogRead(0, handler);
+        this.particle.analogRead(0, handler);
         this.state.socket.emit("data", receiving);
       };
     }
@@ -308,7 +308,7 @@ exports["Spark"] = {
     exports[entry].write = function(test) {
       test.expect(4);
 
-      this.spark[fn](pin, value);
+      this.particle[fn](pin, value);
 
       test.ok(this.socketwrite.calledOnce);
 
@@ -324,9 +324,9 @@ exports["Spark"] = {
     exports[entry].stored = function(test) {
       test.expect(1);
 
-      this.spark[fn](pin, value);
+      this.particle[fn](pin, value);
 
-      test.equal(this.spark.pins[index].value, value);
+      test.equal(this.particle.pins[index].value, value);
 
       test.done();
     };
@@ -334,18 +334,18 @@ exports["Spark"] = {
 });
 
 
-exports["Spark.prototype.servoWrite"] = {
+exports["Particle.prototype.servoWrite"] = {
   setUp: function(done) {
     this.clock = sinon.useFakeTimers();
 
     this.state = new State();
     this.map = sinon.stub(Map.prototype, "get").returns(this.state);
     this.socketwrite = sinon.spy(this.state.socket, "write");
-    this.connect = sinon.stub(Spark.prototype, "connect", function(handler) {
+    this.connect = sinon.stub(Particle.prototype, "connect", function(handler) {
       handler(null, {cmd: "VarReturn", result: "127.0.0.1:48879"});
     });
 
-    this.spark = new Spark({
+    this.particle = new Particle({
       token: "token",
       deviceId: "deviceId"
     });
@@ -361,7 +361,7 @@ exports["Spark.prototype.servoWrite"] = {
 
     var sent = [2, 0, 180];
 
-    this.spark.analogWrite("D0", 180);
+    this.particle.analogWrite("D0", 180);
 
     var buffer = this.socketwrite.args[0][0];
 
@@ -375,7 +375,7 @@ exports["Spark.prototype.servoWrite"] = {
 
     var sent = [2, 10, 255];
 
-    this.spark.analogWrite("A0", 255);
+    this.particle.analogWrite("A0", 255);
 
     var buffer = this.socketwrite.args[0][0];
 
@@ -390,7 +390,7 @@ exports["Spark.prototype.servoWrite"] = {
 
     var sent = [0x41, 0, 180];
 
-    this.spark.servoWrite("D0", 180);
+    this.particle.servoWrite("D0", 180);
 
     var buffer = this.socketwrite.args[0][0];
 
@@ -405,7 +405,7 @@ exports["Spark.prototype.servoWrite"] = {
 
     var sent = [0x41, 10, 180];
 
-    this.spark.servoWrite("A0", 180);
+    this.particle.servoWrite("A0", 180);
 
     var buffer = this.socketwrite.args[0][0];
 
@@ -418,18 +418,18 @@ exports["Spark.prototype.servoWrite"] = {
 
 
 
-exports["Spark.prototype.pinMode"] = {
+exports["Particle.prototype.pinMode"] = {
   setUp: function(done) {
 
     this.clock = sinon.useFakeTimers();
     this.state = new State();
     this.map = sinon.stub(Map.prototype, "get").returns(this.state);
     this.socketwrite = sinon.spy(this.state.socket, "write");
-    this.connect = sinon.stub(Spark.prototype, "connect", function(handler) {
+    this.connect = sinon.stub(Particle.prototype, "connect", function(handler) {
       handler(null, {cmd: "VarReturn", result: "127.0.0.1:48879"});
     });
 
-    this.spark = new Spark({
+    this.particle = new Particle({
       token: "token",
       deviceId: "deviceId"
     });
@@ -445,7 +445,7 @@ exports["Spark.prototype.pinMode"] = {
 
     var sent = [0, 11, 1];
 
-    this.spark.pinMode("A1", 1);
+    this.particle.pinMode("A1", 1);
     test.ok(this.socketwrite.calledOnce);
 
     var buffer = this.socketwrite.args[0][0];
@@ -460,7 +460,7 @@ exports["Spark.prototype.pinMode"] = {
 
     var sent = [0, 11, 0];
 
-    this.spark.pinMode("A1", 0);
+    this.particle.pinMode("A1", 0);
     test.ok(this.socketwrite.calledOnce);
 
     var buffer = this.socketwrite.args[0][0];
@@ -476,7 +476,7 @@ exports["Spark.prototype.pinMode"] = {
 
     var sent = [0, 11, 2];
 
-    this.spark.pinMode(1, 2);
+    this.particle.pinMode(1, 2);
     test.ok(this.socketwrite.calledOnce);
 
     var buffer = this.socketwrite.args[0][0];
@@ -492,7 +492,7 @@ exports["Spark.prototype.pinMode"] = {
 
     var sent = [0, 0, 1];
 
-    this.spark.pinMode("D0", 1);
+    this.particle.pinMode("D0", 1);
 
     test.ok(this.socketwrite.calledOnce);
 
@@ -509,7 +509,7 @@ exports["Spark.prototype.pinMode"] = {
 
     var sent = [0, 0, 0];
 
-    this.spark.pinMode("D0", 0);
+    this.particle.pinMode("D0", 0);
 
     test.ok(this.socketwrite.calledOnce);
 
@@ -526,7 +526,7 @@ exports["Spark.prototype.pinMode"] = {
 
     var sent = [0, 0, 4];
 
-    this.spark.pinMode("D0", 4);
+    this.particle.pinMode("D0", 4);
 
     test.ok(this.socketwrite.calledOnce);
 
@@ -543,7 +543,7 @@ exports["Spark.prototype.pinMode"] = {
 
     var sent = [0, 0, 1];
 
-    this.spark.pinMode("D0", 3);
+    this.particle.pinMode("D0", 3);
 
     test.ok(this.socketwrite.calledOnce);
 
@@ -559,14 +559,14 @@ exports["Spark.prototype.pinMode"] = {
     test.expect(9);
 
     try {
-      this.spark.pinMode("D0", 3);
-      this.spark.pinMode("D1", 3);
-      this.spark.pinMode("A0", 3);
-      this.spark.pinMode("A1", 3);
-      this.spark.pinMode("A4", 3);
-      this.spark.pinMode("A5", 3);
-      this.spark.pinMode("A6", 3);
-      this.spark.pinMode("A7", 3);
+      this.particle.pinMode("D0", 3);
+      this.particle.pinMode("D1", 3);
+      this.particle.pinMode("A0", 3);
+      this.particle.pinMode("A1", 3);
+      this.particle.pinMode("A4", 3);
+      this.particle.pinMode("A5", 3);
+      this.particle.pinMode("A6", 3);
+      this.particle.pinMode("A7", 3);
 
       test.ok(true);
     } catch(e) {
@@ -574,56 +574,56 @@ exports["Spark.prototype.pinMode"] = {
     }
 
     try {
-      this.spark.pinMode("D2", 3);
+      this.particle.pinMode("D2", 3);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("D3", 3);
+      this.particle.pinMode("D3", 3);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("D4", 3);
+      this.particle.pinMode("D4", 3);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("D5", 3);
+      this.particle.pinMode("D5", 3);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("D6", 3);
+      this.particle.pinMode("D6", 3);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("D7", 3);
+      this.particle.pinMode("D7", 3);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("A2", 3);
+      this.particle.pinMode("A2", 3);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("A3", 3);
+      this.particle.pinMode("A3", 3);
       test.ok(false);
     } catch(e) {
       test.ok(true);
@@ -636,14 +636,14 @@ exports["Spark.prototype.pinMode"] = {
     test.expect(9);
 
     try {
-      this.spark.pinMode("D0", 4);
-      this.spark.pinMode("D1", 4);
-      this.spark.pinMode("A0", 4);
-      this.spark.pinMode("A1", 4);
-      this.spark.pinMode("A4", 4);
-      this.spark.pinMode("A5", 4);
-      this.spark.pinMode("A6", 4);
-      this.spark.pinMode("A7", 4);
+      this.particle.pinMode("D0", 4);
+      this.particle.pinMode("D1", 4);
+      this.particle.pinMode("A0", 4);
+      this.particle.pinMode("A1", 4);
+      this.particle.pinMode("A4", 4);
+      this.particle.pinMode("A5", 4);
+      this.particle.pinMode("A6", 4);
+      this.particle.pinMode("A7", 4);
 
       test.ok(true);
     } catch(e) {
@@ -651,56 +651,56 @@ exports["Spark.prototype.pinMode"] = {
     }
 
     try {
-      this.spark.pinMode("D2", 4);
+      this.particle.pinMode("D2", 4);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("D3", 4);
+      this.particle.pinMode("D3", 4);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("D4", 4);
+      this.particle.pinMode("D4", 4);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("D5", 4);
+      this.particle.pinMode("D5", 4);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("D6", 4);
+      this.particle.pinMode("D6", 4);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("D7", 4);
+      this.particle.pinMode("D7", 4);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("A2", 4);
+      this.particle.pinMode("A2", 4);
       test.ok(false);
     } catch(e) {
       test.ok(true);
     }
 
     try {
-      this.spark.pinMode("A3", 4);
+      this.particle.pinMode("A3", 4);
       test.ok(false);
     } catch(e) {
       test.ok(true);
@@ -710,18 +710,18 @@ exports["Spark.prototype.pinMode"] = {
   }
 };
 
-exports["Spark.prototype.internalRGB"] = {
+exports["Particle.prototype.internalRGB"] = {
   setUp: function(done) {
 
     this.clock = sinon.useFakeTimers();
     this.state = new State();
     this.map = sinon.stub(Map.prototype, "get").returns(this.state);
     this.socketwrite = sinon.spy(this.state.socket, "write");
-    this.connect = sinon.stub(Spark.prototype, "connect", function(handler) {
+    this.connect = sinon.stub(Particle.prototype, "connect", function(handler) {
       handler(null, {cmd: "VarReturn", result: "127.0.0.1:48879"});
     });
 
-    this.spark = new Spark({
+    this.particle = new Particle({
       token: "token",
       deviceId: "deviceId"
     });
@@ -736,13 +736,13 @@ exports["Spark.prototype.internalRGB"] = {
   get: function(test) {
     test.expect(3);
 
-    test.deepEqual(this.spark.internalRGB(), {
+    test.deepEqual(this.particle.internalRGB(), {
       red: null, green: null, blue: null
     });
     test.ok(this.socketwrite.notCalled);
 
-    this.spark.internalRGB(10, 20, 30);
-    test.deepEqual(this.spark.internalRGB(), {
+    this.particle.internalRGB(10, 20, 30);
+    test.deepEqual(this.particle.internalRGB(), {
       red: 10, green: 20, blue: 30
     });
 
@@ -752,14 +752,14 @@ exports["Spark.prototype.internalRGB"] = {
   setReturnsThis: function(test) {
     test.expect(1);
 
-    test.equal(this.spark.internalRGB(0, 0, 0), this.spark);
+    test.equal(this.particle.internalRGB(0, 0, 0), this.particle);
     test.done();
   },
 
   setWithThreeArgs: function(test) {
     test.expect(6);
 
-    this.spark.internalRGB(0, 0, 0);
+    this.particle.internalRGB(0, 0, 0);
 
     test.ok(this.socketwrite.called);
 
@@ -770,7 +770,7 @@ exports["Spark.prototype.internalRGB"] = {
     test.equal(buffer.readUInt8(2), 0);
     test.equal(buffer.readUInt8(3), 0);
 
-    test.deepEqual(this.spark.internalRGB(), {
+    test.deepEqual(this.particle.internalRGB(), {
       red: 0, green: 0, blue: 0
     });
 
@@ -780,7 +780,7 @@ exports["Spark.prototype.internalRGB"] = {
   setWithArrayOfThreeBytes: function(test) {
     test.expect(6);
 
-    this.spark.internalRGB([0, 0, 0]);
+    this.particle.internalRGB([0, 0, 0]);
 
     test.ok(this.socketwrite.called);
 
@@ -791,7 +791,7 @@ exports["Spark.prototype.internalRGB"] = {
     test.equal(buffer.readUInt8(2), 0);
     test.equal(buffer.readUInt8(3), 0);
 
-    test.deepEqual(this.spark.internalRGB(), {
+    test.deepEqual(this.particle.internalRGB(), {
       red: 0, green: 0, blue: 0
     });
 
@@ -801,7 +801,7 @@ exports["Spark.prototype.internalRGB"] = {
   setWithObjectContainingPropertiesRGB: function(test) {
     test.expect(6);
 
-    this.spark.internalRGB({
+    this.particle.internalRGB({
       red: 0, green: 0, blue: 0
     });
 
@@ -814,7 +814,7 @@ exports["Spark.prototype.internalRGB"] = {
     test.equal(buffer.readUInt8(2), 0);
     test.equal(buffer.readUInt8(3), 0);
 
-    test.deepEqual(this.spark.internalRGB(), {
+    test.deepEqual(this.particle.internalRGB(), {
       red: 0, green: 0, blue: 0
     });
 
@@ -824,7 +824,7 @@ exports["Spark.prototype.internalRGB"] = {
   setWithHexString: function(test) {
     test.expect(6);
 
-    this.spark.internalRGB("#000000");
+    this.particle.internalRGB("#000000");
 
     test.ok(this.socketwrite.called);
 
@@ -835,7 +835,7 @@ exports["Spark.prototype.internalRGB"] = {
     test.equal(buffer.readUInt8(2), 0);
     test.equal(buffer.readUInt8(3), 0);
 
-    test.deepEqual(this.spark.internalRGB(), {
+    test.deepEqual(this.particle.internalRGB(), {
       red: 0, green: 0, blue: 0
     });
 
@@ -845,7 +845,7 @@ exports["Spark.prototype.internalRGB"] = {
   setWithHexStringNoPrefix: function(test) {
     test.expect(6);
 
-    this.spark.internalRGB("000000");
+    this.particle.internalRGB("000000");
 
     test.ok(this.socketwrite.called);
 
@@ -856,7 +856,7 @@ exports["Spark.prototype.internalRGB"] = {
     test.equal(buffer.readUInt8(2), 0);
     test.equal(buffer.readUInt8(3), 0);
 
-    test.deepEqual(this.spark.internalRGB(), {
+    test.deepEqual(this.particle.internalRGB(), {
       red: 0, green: 0, blue: 0
     });
 
@@ -866,7 +866,7 @@ exports["Spark.prototype.internalRGB"] = {
   setConstrainsValues: function(test) {
     test.expect(6);
 
-    this.spark.internalRGB(300, -1, 256);
+    this.particle.internalRGB(300, -1, 256);
 
     test.ok(this.socketwrite.called);
 
@@ -877,7 +877,7 @@ exports["Spark.prototype.internalRGB"] = {
     test.equal(buffer.readUInt8(2), 0);
     test.equal(buffer.readUInt8(3), 255);
 
-    test.deepEqual(this.spark.internalRGB(), {
+    test.deepEqual(this.particle.internalRGB(), {
       red: 255, green: 0, blue: 255
     });
 
@@ -885,63 +885,63 @@ exports["Spark.prototype.internalRGB"] = {
   },
 
   setBadValues: function(test) {
-    var spark = this.spark;
+    var particle = this.particle;
 
     test.expect(14);
 
     // null
     test.throws(function() {
-      spark.internalRGB(null);
+      particle.internalRGB(null);
     });
 
     // shorthand not supported
     test.throws(function() {
-      spark.internalRGB("#fff");
+      particle.internalRGB("#fff");
     });
 
     // bad hex
     test.throws(function() {
-      spark.internalRGB("#ggffff");
+      particle.internalRGB("#ggffff");
     });
     test.throws(function() {
-      spark.internalRGB("#ggffffff");
+      particle.internalRGB("#ggffffff");
     });
     test.throws(function() {
-      spark.internalRGB("#ffffffff");
+      particle.internalRGB("#ffffffff");
     });
 
     // by params
     test.throws(function() {
-      spark.internalRGB(10, 20, null);
+      particle.internalRGB(10, 20, null);
     });
     test.throws(function() {
-      spark.internalRGB(10, 20);
+      particle.internalRGB(10, 20);
     });
     test.throws(function() {
-      spark.internalRGB(10, undefined, 30);
+      particle.internalRGB(10, undefined, 30);
     });
 
 
     // by array
     test.throws(function() {
-      spark.internalRGB([10, 20, null]);
+      particle.internalRGB([10, 20, null]);
     });
     test.throws(function() {
-      spark.internalRGB([10, undefined, 30]);
+      particle.internalRGB([10, undefined, 30]);
     });
     test.throws(function() {
-      spark.internalRGB([10, 20]);
+      particle.internalRGB([10, 20]);
     });
 
     // by object
     test.throws(function() {
-      spark.internalRGB({red: 255, green: 100});
+      particle.internalRGB({red: 255, green: 100});
     });
     test.throws(function() {
-      spark.internalRGB({red: 255, green: 100, blue: null});
+      particle.internalRGB({red: 255, green: 100, blue: null});
     });
     test.throws(function() {
-      spark.internalRGB({red: 255, green: 100, blue: undefined});
+      particle.internalRGB({red: 255, green: 100, blue: undefined});
     });
 
 


### PR DESCRIPTION
Trying to update everything to be called Particle instead of Spark.  I am anticipating some confusion if this doesn't happen.

There are a few things that still need to be done, probably after this PR?

1. The spark-io repo should change to particle-io
  a. Update the package.json accordingly
  b. Update NPM (spark-io and particle-io) to point to the re-named repo
  c. Alternatively, create a new repo called particle-io and deprecate spark-io?  
2. Update Travis to be spark-io
3. Similar PR for Voodoospark (to rename to Voodoophoton?) I realize that is a different repo, but when that gets done, need to update the references here.